### PR TITLE
3-kotlin-extensions

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,5 +1,6 @@
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
+apply plugin: 'kotlin-android-extensions'
 
 android {
     compileSdkVersion 25

--- a/app/src/main/java/sample/maps/ui/list/LocationListActivity.kt
+++ b/app/src/main/java/sample/maps/ui/list/LocationListActivity.kt
@@ -31,7 +31,7 @@ class LocationListActivity : AppCompatActivity() {
     }
 
     private fun initComponents() {
-        locationListView = findViewById(R.id.list_view) as LocationListViewImpl
+        locationListView = findViewById(R.id.locationListView) as LocationListViewImpl
     }
 
     override fun onStart() {

--- a/app/src/main/java/sample/maps/ui/list/LocationListActivity.kt
+++ b/app/src/main/java/sample/maps/ui/list/LocationListActivity.kt
@@ -3,6 +3,7 @@ package sample.maps.ui.list
 import android.os.Bundle
 import android.support.v7.app.AppCompatActivity
 import android.view.MenuItem
+import kotlinx.android.synthetic.main.location_list_activity.*
 import sample.maps.MapsApplication
 import sample.maps.R
 import sample.maps.injection.component.DaggerActivityComponent
@@ -12,8 +13,6 @@ import javax.inject.Inject
 class LocationListActivity : AppCompatActivity() {
     @Inject
     lateinit var locationListPresenter: LocationListPresenter
-    private lateinit var locationListView: LocationListViewImpl
-
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -22,16 +21,11 @@ class LocationListActivity : AppCompatActivity() {
 
         setContentView(R.layout.location_list_activity)
 
-        initComponents()
         initActionBar()
     }
 
     private fun initActionBar() {
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
-    }
-
-    private fun initComponents() {
-        locationListView = findViewById(R.id.locationListView) as LocationListViewImpl
     }
 
     override fun onStart() {

--- a/app/src/main/java/sample/maps/ui/list/LocationListViewImpl.kt
+++ b/app/src/main/java/sample/maps/ui/list/LocationListViewImpl.kt
@@ -25,7 +25,7 @@ class LocationListViewImpl(context: Context, attributeSet: AttributeSet)
                 .from(context)
                 .inflate(R.layout.location_list_view, this, true)
 
-        (findViewById(R.id.list) as RecyclerView).apply {
+        (findViewById(R.id.locationList) as RecyclerView).apply {
             layoutManager = LinearLayoutManager(context, LinearLayoutManager.VERTICAL, false)
             adapter = itemsAdapter
             isNestedScrollingEnabled = false
@@ -76,7 +76,7 @@ class LocationListViewImpl(context: Context, attributeSet: AttributeSet)
     }
 
     private inner class LocationViewHolder(itemView: View?) : RecyclerView.ViewHolder(itemView) {
-        val label: TextView = itemView?.findViewById(R.id.label) as TextView
+        val label: TextView = itemView?.findViewById(R.id.locationLabel) as TextView
 
         fun setViewModel(model: Location) {
             label.text = model.toString()

--- a/app/src/main/java/sample/maps/ui/list/LocationListViewImpl.kt
+++ b/app/src/main/java/sample/maps/ui/list/LocationListViewImpl.kt
@@ -9,6 +9,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.FrameLayout
 import android.widget.TextView
+import kotlinx.android.synthetic.main.location_list_view.view.*
 import sample.maps.R
 import sample.maps.model.Location
 
@@ -25,7 +26,7 @@ class LocationListViewImpl(context: Context, attributeSet: AttributeSet)
                 .from(context)
                 .inflate(R.layout.location_list_view, this, true)
 
-        (findViewById(R.id.locationList) as RecyclerView).apply {
+        locationList.apply {
             layoutManager = LinearLayoutManager(context, LinearLayoutManager.VERTICAL, false)
             adapter = itemsAdapter
             isNestedScrollingEnabled = false
@@ -75,8 +76,9 @@ class LocationListViewImpl(context: Context, attributeSet: AttributeSet)
 
     }
 
-    private inner class LocationViewHolder(itemView: View?) : RecyclerView.ViewHolder(itemView) {
-        val label: TextView = itemView?.findViewById(R.id.locationLabel) as TextView
+    private inner class LocationViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
+
+        val label = itemView.findViewById(R.id.locationLabel) as TextView
 
         fun setViewModel(model: Location) {
             label.text = model.toString()

--- a/app/src/main/java/sample/maps/ui/maps/MapsActivity.kt
+++ b/app/src/main/java/sample/maps/ui/maps/MapsActivity.kt
@@ -36,9 +36,8 @@ class MapsActivity : AppCompatActivity() {
     }
 
     private fun initComponents(savedInstanceState: Bundle?) {
-        mapView.onCreate(savedInstanceState)
-        mapView.setListener(mapsPresenter)
-
+        mapViewImpl.onCreate(savedInstanceState)
+        mapViewImpl.setListener(mapsPresenter)
     }
 
     private fun initDagger() {
@@ -63,38 +62,38 @@ class MapsActivity : AppCompatActivity() {
 
     override fun onStart() {
         super.onStart()
-        mapView.onStart()
-        mapsPresenter.resume(mapView)
+        mapViewImpl.onStart()
+        mapsPresenter.resume(mapViewImpl)
     }
 
     override fun onResume() {
         super.onResume()
-        mapView.onResume()
+        mapViewImpl.onResume()
     }
 
     override fun onStop() {
         super.onStop()
-        mapView.onStop()
+        mapViewImpl.onStop()
         mapsPresenter.pause()
     }
 
     override fun onPause() {
         super.onPause()
-        mapView.onPause()
+        mapViewImpl.onPause()
     }
 
     override fun onDestroy() {
         super.onDestroy()
-        mapView.onDestroy()
+        mapViewImpl.onDestroy()
     }
 
     override fun onLowMemory() {
         super.onLowMemory()
-        mapView.onLowMemory()
+        mapViewImpl.onLowMemory()
     }
 
     override fun onSaveInstanceState(outState: Bundle?) {
         super.onSaveInstanceState(outState)
-        mapView.onSaveInstanceState(outState)
+        mapViewImpl.onSaveInstanceState(outState)
     }
 }

--- a/app/src/main/java/sample/maps/ui/maps/MapsActivity.kt
+++ b/app/src/main/java/sample/maps/ui/maps/MapsActivity.kt
@@ -6,6 +6,7 @@ import android.support.v7.app.AppCompatActivity
 import android.view.Menu
 import android.view.MenuItem
 import com.tbruyelle.rxpermissions2.RxPermissions
+import kotlinx.android.synthetic.main.maps_activity.*
 import sample.maps.MapsApplication
 import sample.maps.R
 import sample.maps.injection.component.DaggerActivityComponent
@@ -19,7 +20,6 @@ class MapsActivity : AppCompatActivity() {
 
     @Inject
     lateinit var mapsPresenter: MapsPresenter
-    private lateinit var mapsView: MapsViewImpl
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -36,9 +36,8 @@ class MapsActivity : AppCompatActivity() {
     }
 
     private fun initComponents(savedInstanceState: Bundle?) {
-        mapsView = findViewById(R.id.map_view) as MapsViewImpl
-        mapsView.onCreate(savedInstanceState)
-        mapsView.setListener(mapsPresenter)
+        mapView.onCreate(savedInstanceState)
+        mapView.setListener(mapsPresenter)
 
     }
 
@@ -57,46 +56,45 @@ class MapsActivity : AppCompatActivity() {
 
     override fun onOptionsItemSelected(item: MenuItem?): Boolean {
         when (item?.itemId) {
-            R.id.list -> mapsPresenter.locationListClicked()
+            R.id.locationList -> mapsPresenter.locationListClicked()
         }
         return super.onOptionsItemSelected(item)
     }
 
     override fun onStart() {
         super.onStart()
-        mapsView.onStart()
-        mapsPresenter.resume(mapsView)
+        mapView.onStart()
+        mapsPresenter.resume(mapView)
     }
 
     override fun onResume() {
         super.onResume()
-        mapsView.onResume()
+        mapView.onResume()
     }
 
     override fun onStop() {
         super.onStop()
-        mapsView.onStop()
+        mapView.onStop()
         mapsPresenter.pause()
     }
 
     override fun onPause() {
         super.onPause()
-        mapsView.onPause()
-
+        mapView.onPause()
     }
 
     override fun onDestroy() {
         super.onDestroy()
-        mapsView.onDestroy()
+        mapView.onDestroy()
     }
 
     override fun onLowMemory() {
         super.onLowMemory()
-        mapsView.onLowMemory()
+        mapView.onLowMemory()
     }
 
     override fun onSaveInstanceState(outState: Bundle?) {
         super.onSaveInstanceState(outState)
-        mapsView.onSaveInstanceState(outState)
+        mapView.onSaveInstanceState(outState)
     }
 }

--- a/app/src/main/java/sample/maps/ui/maps/MapsViewImpl.kt
+++ b/app/src/main/java/sample/maps/ui/maps/MapsViewImpl.kt
@@ -3,7 +3,6 @@ package sample.maps.ui.maps
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
-import android.os.LocaleList
 import android.util.AttributeSet
 import android.view.LayoutInflater
 import android.widget.FrameLayout
@@ -38,7 +37,7 @@ class MapsViewImpl(context: Context, attributeSet: AttributeSet)
 
         subscribeForStateUpdate()
 
-        findViewById(R.id.add).setOnClickListener { listener?.addLocationClicked() }
+        findViewById(R.id.addButton).setOnClickListener { listener?.addLocationClicked() }
     }
 
 

--- a/app/src/main/java/sample/maps/ui/maps/MapsViewImpl.kt
+++ b/app/src/main/java/sample/maps/ui/maps/MapsViewImpl.kt
@@ -12,18 +12,18 @@ import com.google.android.gms.maps.model.LatLng
 import com.google.android.gms.maps.model.MarkerOptions
 import io.reactivex.processors.BehaviorProcessor
 import io.reactivex.rxkotlin.Flowables
+import kotlinx.android.synthetic.main.maps_view.view.*
 import sample.maps.R
 import sample.maps.ui.list.LocationListActivity
 
 /**
  * Implementation of [MapsView]
  */
-class MapsViewImpl(context: Context, attributeSet: AttributeSet)
-    : MapsView, FrameLayout(context, attributeSet) {
+class MapsViewImpl @JvmOverloads constructor(
+        context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0
+) : MapsView, FrameLayout(context, attrs, defStyleAttr) {
 
     private var listener: MapsView.Listener? = null
-
-    private var mapView: MapView
 
     private val googleMap = BehaviorProcessor.create<GoogleMap>()
     private val state = BehaviorProcessor.create<MapsView.State>()
@@ -33,11 +33,9 @@ class MapsViewImpl(context: Context, attributeSet: AttributeSet)
                 .from(context)
                 .inflate(R.layout.maps_view, this, true)
 
-        mapView = (findViewById(R.id.map) as MapView)
-
         subscribeForStateUpdate()
 
-        findViewById(R.id.addButton).setOnClickListener { listener?.addLocationClicked() }
+        addButton.setOnClickListener { listener?.addLocationClicked() }
     }
 
 
@@ -64,8 +62,8 @@ class MapsViewImpl(context: Context, attributeSet: AttributeSet)
      * Method to work with [MapView] lifecycle
      */
     fun onCreate(bundle: Bundle?) {
-        mapView.onCreate(bundle)
-        mapView.getMapAsync {
+        googleMapView.onCreate(bundle)
+        googleMapView.getMapAsync {
             if (it != null) {
                 with(it) {
                     uiSettings.isMyLocationButtonEnabled = true
@@ -81,46 +79,46 @@ class MapsViewImpl(context: Context, attributeSet: AttributeSet)
      * Method to work with [MapView] lifecycle
      */
     fun onStart() {
-        mapView.onStart()
+        googleMapView.onStart()
     }
 
     /**
      * Method to work with [MapView] lifecycle
      */
     fun onStop() {
-        mapView.onStop()
+        googleMapView.onStop()
     }
 
     /**
      * Method to work with [MapView] lifecycle
      */
     fun onResume() {
-        mapView.onResume()
+        googleMapView.onResume()
     }
 
     /**
      * Method to work with [MapView] lifecycle
      */
     fun onPause() {
-        mapView.onPause()
+        googleMapView.onPause()
     }
 
     /**
      * Method to work with [MapView] lifecycle
      */
     fun onDestroy() {
-        mapView.onDestroy()
+        googleMapView.onDestroy()
     }
 
     /**
      * Method to work with [MapView] lifecycle
      */
     fun onLowMemory() {
-        mapView.onLowMemory()
+        googleMapView.onLowMemory()
     }
 
     fun onSaveInstanceState(bundle: Bundle?) {
-        mapView.onSaveInstanceState(bundle)
+        googleMapView.onSaveInstanceState(bundle)
     }
 
     override fun updateState(newState: MapsView.State) {

--- a/app/src/main/res/layout/location_list_activity.xml
+++ b/app/src/main/res/layout/location_list_activity.xml
@@ -3,7 +3,7 @@
     android:layout_height="match_parent">
 
     <sample.maps.ui.list.LocationListViewImpl
-        android:id="@+id/list_view"
+        android:id="@+id/locationListView"
         android:layout_height="match_parent"
         android:layout_width="match_parent"/>
 </FrameLayout>

--- a/app/src/main/res/layout/location_list_item.xml
+++ b/app/src/main/res/layout/location_list_item.xml
@@ -11,7 +11,7 @@
         android:background="@color/colorPrimaryDark"/>
 
     <TextView
-        android:id="@+id/label"
+        android:id="@+id/locationLabel"
         android:layout_width="match_parent"
         android:layout_height="64dp"
         android:gravity="center_vertical"

--- a/app/src/main/res/layout/location_list_view.xml
+++ b/app/src/main/res/layout/location_list_view.xml
@@ -5,7 +5,7 @@
     android:splitMotionEvents="false">
 
     <android.support.v7.widget.RecyclerView
-        android:id="@+id/list"
+        android:id="@+id/locationList"
         android:layout_width="match_parent"
         android:layout_height="wrap_content" />
 

--- a/app/src/main/res/layout/maps_activity.xml
+++ b/app/src/main/res/layout/maps_activity.xml
@@ -3,7 +3,7 @@
     android:layout_height="match_parent">
 
     <sample.maps.ui.maps.MapsViewImpl
-        android:id="@+id/mapView"
+        android:id="@+id/mapViewImpl"
         android:layout_height="match_parent"
         android:layout_width="match_parent"/>
 </FrameLayout>

--- a/app/src/main/res/layout/maps_activity.xml
+++ b/app/src/main/res/layout/maps_activity.xml
@@ -3,7 +3,7 @@
     android:layout_height="match_parent">
 
     <sample.maps.ui.maps.MapsViewImpl
-        android:id="@+id/map_view"
+        android:id="@+id/mapView"
         android:layout_height="match_parent"
         android:layout_width="match_parent"/>
 </FrameLayout>

--- a/app/src/main/res/layout/maps_view.xml
+++ b/app/src/main/res/layout/maps_view.xml
@@ -8,7 +8,7 @@
         android:layout_width="match_parent"/>
 
     <android.support.design.widget.FloatingActionButton
-        android:id="@+id/add"
+        android:id="@+id/addButton"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:elevation="4dp"

--- a/app/src/main/res/layout/maps_view.xml
+++ b/app/src/main/res/layout/maps_view.xml
@@ -3,7 +3,7 @@
     android:layout_height="match_parent">
 
     <com.google.android.gms.maps.MapView
-        android:id="@+id/map"
+        android:id="@+id/googleMapView"
         android:layout_height="match_parent"
         android:layout_width="match_parent"/>
 

--- a/app/src/main/res/menu/maps_menu.xml
+++ b/app/src/main/res/menu/maps_menu.xml
@@ -2,7 +2,7 @@
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">
     <item
-        android:id="@+id/list"
+        android:id="@+id/locationList"
         app:showAsAction="always"
         android:title="@string/location_list" />
 </menu>


### PR DESCRIPTION
Also found an issue with naming conflicts. It was "@+id/map" mentioned in `Activity` and the same id in the `ViewImpl`. Since lib is cashing calls to `findViewById`and ignores its own imports during runtime - it will lead to a crash. 
The only workaround, for now, is to use wider varieties of id names.